### PR TITLE
use timeout safely

### DIFF
--- a/s3-helper/s3-helper.go
+++ b/s3-helper/s3-helper.go
@@ -150,20 +150,19 @@ func forwardToS3(w http.ResponseWriter, r *http.Request) {
 
 	var resp *http.Response
 
+        client := &http.Client{
+                Transport: &http.Transport{
+                Proxy: http.ProxyFromEnvironment,
+                DialContext: (&net.Dialer{
+                    Timeout:   conf.S3Timeout * time.Second,
+                    KeepAlive: 1 * time.Second,
+                }).DialContext,
+                IdleConnTimeout:       conf.S3Timeout * time.Second,
+                TLSHandshakeTimeout:   conf.S3Timeout * time.Second,
+                ExpectContinueTimeout: conf.S3Timeout * time.Second,
+        }}
+
 	for {
-		client := &http.Client{
-                        Transport: &http.Transport{
-                        Proxy: http.ProxyFromEnvironment,
-                        DialContext: (&net.Dialer{
-                            Timeout:   conf.S3Timeout * time.Second,
-                            KeepAlive: 1 * time.Second,
-                        }).DialContext,
-                        MaxIdleConns:          100,
-                        IdleConnTimeout:       conf.S3Timeout * time.Second,
-                        MaxIdleConnsPerHost:   1,
-                        TLSHandshakeTimeout:   conf.S3Timeout * time.Second,
-                        ExpectContinueTimeout: conf.S3Timeout * time.Second,
-                }}
 		resp, err = client.Do(r2)
 		if err == nil {
 			break

--- a/s3-helper/s3-helper.go
+++ b/s3-helper/s3-helper.go
@@ -150,15 +150,18 @@ func forwardToS3(w http.ResponseWriter, r *http.Request) {
 
 	var resp *http.Response
 
-        client := &http.Client{
-                Transport: &http.Transport{
-                Proxy: http.ProxyFromEnvironment,
-                DialContext: (&net.Dialer{
-                    Timeout:   conf.S3Timeout,
-                    KeepAlive: 1 * time.Second,
-                }).DialContext,
-                IdleConnTimeout:       conf.S3Timeout,
-        }}
+	// setup client outside of for loop since we don't
+	// need to define it multiple times and failures
+	// shouldn't need a new client
+	client := &http.Client{
+		Transport: &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+			DialContext: (&net.Dialer{
+				Timeout:   conf.S3Timeout,
+				KeepAlive: 1 * time.Second,
+			}).DialContext,
+			IdleConnTimeout: conf.S3Timeout,
+		}}
 
 	for {
 		resp, err = client.Do(r2)

--- a/s3-helper/s3-helper.go
+++ b/s3-helper/s3-helper.go
@@ -151,7 +151,19 @@ func forwardToS3(w http.ResponseWriter, r *http.Request) {
 	var resp *http.Response
 
 	for {
-		client := &http.Client{Timeout: conf.S3Timeout}
+		client := &http.Client{
+                        Transport: &http.Transport{
+                        Proxy: http.ProxyFromEnvironment,
+                        DialContext: (&net.Dialer{
+                            Timeout:   conf.S3Timeout * time.Second,
+                            KeepAlive: 1 * time.Second,
+                        }).DialContext,
+                        MaxIdleConns:          100,
+                        IdleConnTimeout:       conf.S3Timeout * time.Second,
+                        MaxIdleConnsPerHost:   1,
+                        TLSHandshakeTimeout:   conf.S3Timeout * time.Second,
+                        ExpectContinueTimeout: conf.S3Timeout * time.Second,
+                }}
 		resp, err = client.Do(r2)
 		if err == nil {
 			break

--- a/s3-helper/s3-helper.go
+++ b/s3-helper/s3-helper.go
@@ -154,12 +154,10 @@ func forwardToS3(w http.ResponseWriter, r *http.Request) {
                 Transport: &http.Transport{
                 Proxy: http.ProxyFromEnvironment,
                 DialContext: (&net.Dialer{
-                    Timeout:   conf.S3Timeout * time.Second,
+                    Timeout:   conf.S3Timeout,
                     KeepAlive: 1 * time.Second,
                 }).DialContext,
-                IdleConnTimeout:       conf.S3Timeout * time.Second,
-                TLSHandshakeTimeout:   conf.S3Timeout * time.Second,
-                ExpectContinueTimeout: conf.S3Timeout * time.Second,
+                IdleConnTimeout:       conf.S3Timeout,
         }}
 
 	for {


### PR DESCRIPTION
Jira: VOD-2868

the use of Timeout was not good or safe in any way shape or form.
this change uses it so that downloads won't truncate when they
take longer than timeout. Instead they will fail and retry if
they stall/idle for the timeout period as originally intended.